### PR TITLE
Fix parser for command line options

### DIFF
--- a/map_reader.py
+++ b/map_reader.py
@@ -225,7 +225,7 @@ def main():
     tile_zoom = 8
     # parse command line options
     try:
-        for opt, value in getopt.getopt(sys.argv[1:], "g:")[0]:
+        for opt, value in getopt.getopt(sys.argv[1:], "g:t:z:")[0]:
             if opt == "-g":
                 game_player_path = value
             elif opt == "-t":


### PR DESCRIPTION
-g  "C:\Users..":   The folder that contain .map files

 -t "tiles":              The folder that will contain tiles (Optional)

-z 8:                     Zoom level 4-n. Number of tiles to extract around position 0,0 of map.
                            It is in the form of 4^n tiles.It will extract a grid of 2^n*16 tiles on each side.(Optional)
